### PR TITLE
Fix an issue with bool config values

### DIFF
--- a/src/Controller/InstallController.php
+++ b/src/Controller/InstallController.php
@@ -144,7 +144,10 @@ class InstallController extends AppController
                          * database.php.install from plugin config path
                          */
                         foreach (Configure::read('Installer.Connection') as $k => $v) {
-                            $content = str_replace('{default_' . $k . '}', $v, $content);
+                            $search = "{default_{$k}}";
+                            if (strpos($content, $search) !== false) {
+                                $content = str_replace($search, $v, $content);
+                            }
                         }
 
                         /**


### PR DESCRIPTION
The "persist" key was causing issues, because it's a `bool` value and `str_replace` doesn't want to accept a `bool` as the second parameter. I don't actually have a use case to do good testing on how best to handle `bool` values in the `.env` file, so instead this commit only tries to do the replacement if the replace needle is found in the file.